### PR TITLE
fixed-typo for FFT.inverse argument

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,7 @@ var FFT = function (size) {
 				this.outptr, this.size * 2);
     };
     
-    this.inverse = function(cin) {
+    this.inverse = function(cpx) {
 	this.cin.set(cpx);
 	kiss_fft(this.icfg, this.inptr, this.outptr);
 	return new Float32Array(kissFFTModule.HEAPU8.buffer,


### PR DESCRIPTION
I was getting an error using the inverse FFT function `Uncaught ReferenceError: cpx is not defined`
it's working now, although there are no tests set up for it.